### PR TITLE
Fix text_encoder_projection_dim error

### DIFF
--- a/readout_guidance/rg_helpers.py
+++ b/readout_guidance/rg_helpers.py
@@ -243,7 +243,13 @@ def get_context_sdxl(
     )
     context = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
     add_text_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
-    add_time_ids = model._get_add_time_ids(original_size, crops_coords_top_left, target_size, dtype=prompt_embeds.dtype)
+    
+    if model.text_encoder_2 is None:
+        text_encoder_projection_dim = int(pooled_prompt_embeds.shape[-1])
+    else:
+        text_encoder_projection_dim = model.text_encoder_2.config.projection_dim
+    
+    add_time_ids = model._get_add_time_ids(original_size, crops_coords_top_left, target_size, dtype=prompt_embeds.dtype, text_encoder_projection_dim=text_encoder_projection_dim)
     add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0)
     add_time_ids = add_time_ids.repeat((batch_size, 1))
     context = context.to(device).to(dtype)


### PR DESCRIPTION
Hey!
When trying to run the spatial example I noticed that I kept getting an issue relating to the `text_encoder_projection_dim` being None. There was some talk on diffusers trying to fix this on their end [here](https://github.com/huggingface/diffusers/issues/5824), but it seems they decided to leave it alone since the `_get_add_time_ids` is a private function that they figured would only be called correctly by the library itself. However, since that's being called incorrectly here in `rg_helper.py`, I fixed it by referencing how its called in the [diffusers library](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py) (line 1115 and on). This fixed the error for me!